### PR TITLE
Added CreateFileEto to enable remote file creation but record via MQ

### DIFF
--- a/src/EasyAbp.FileManagement.Domain.Shared/EasyAbp/FileManagement/Files/CreateFileEto.cs
+++ b/src/EasyAbp.FileManagement.Domain.Shared/EasyAbp/FileManagement/Files/CreateFileEto.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace EasyAbp.FileManagement.Files
+{
+    [Serializable]
+    public class CreateFileEto
+    {
+        [Required]
+        public string FileContainerName { get; set; }
+
+        [Required]
+        public string FileName { get; set; }
+
+        public string MimeType { get; set; }
+
+        public FileType FileType { get; set; }
+
+        public Guid? ParentId { get; set; }
+
+        public Guid? OwnerUserId { get; set; }
+    }
+}

--- a/src/EasyAbp.FileManagement.Domain/EasyAbp/FileManagement/Files/CreateFileEventHandler.cs
+++ b/src/EasyAbp.FileManagement.Domain/EasyAbp/FileManagement/Files/CreateFileEventHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Uow;
+
+namespace EasyAbp.FileManagement.Files
+{
+    public class CreateFileEventHandler : IDistributedEventHandler<CreateFileEto>, ITransientDependency
+    {
+        private readonly IFileRepository _fileRepository;
+
+        private readonly IFileManager _fileManager;
+
+        public CreateFileEventHandler(IFileRepository fileRepository, IFileManager fileManager)
+        {
+            _fileRepository = fileRepository;
+            _fileManager = fileManager;
+        }
+
+        [UnitOfWork(true)]
+        public virtual async Task HandleEventAsync(CreateFileEto eventData)
+        {
+            var parent = eventData.ParentId.HasValue ? await _fileRepository.FindAsync(eventData.ParentId.Value) : null;
+
+            var file = await _fileManager.CreateAsync(eventData.FileContainerName, eventData.OwnerUserId, eventData.FileName, eventData.MimeType, eventData.FileType, parent, null);
+
+            await _fileRepository.InsertAsync(file, true);
+        }
+    }
+}


### PR DESCRIPTION
I think we need a ETO to allow user to create files using abp blob module but also being able to simultaneously make a record(File) in the file management module. Remote calls between microservices to create files via IFileAppService is not very efficient.