### PR TITLE
filter files by fileName or extraProperties

### DIFF
--- a/src/EasyAbp.FileManagement.Application.Contracts/EasyAbp/FileManagement/Files/Dtos/GetFileListInput.cs
+++ b/src/EasyAbp.FileManagement.Application.Contracts/EasyAbp/FileManagement/Files/Dtos/GetFileListInput.cs
@@ -14,5 +14,7 @@ namespace EasyAbp.FileManagement.Files.Dtos
         public Guid? OwnerUserId { get; set; }
         
         public bool DirectoryOnly { get; set; }
+
+        public string Filter { get; set; }
     }
 }

--- a/src/EasyAbp.FileManagement.Application/EasyAbp/FileManagement/Files/FileAppService.cs
+++ b/src/EasyAbp.FileManagement.Application/EasyAbp/FileManagement/Files/FileAppService.cs
@@ -77,7 +77,10 @@ namespace EasyAbp.FileManagement.Files
                             x.FileContainerName == input.FileContainerName)
                 .WhereIf(input.DirectoryOnly, x => x.FileType == FileType.Directory)
                 .OrderBy(x => x.FileType)
-                .ThenBy(x => x.FileName);
+                .ThenBy(x => x.FileName)
+                .AsEnumerable()
+                .WhereIf(!input.Filter.IsNullOrEmpty(), x => x.FileName.Contains(input.Filter) || x.ExtraProperties.Values.Any(v => (v ?? "").ToString().Contains(input.Filter)))
+                .AsQueryable();
         }
 
         [Authorize]


### PR DESCRIPTION
GetFileListInput继承ExtensibleObject后可以精确查找拓展属性，但是会丢失分页属性。因此当前只能模糊查询到拓展属性。