### PR TITLE
Update FileBlobNameGenerator.cs

### DIFF
--- a/src/EasyAbp.FileManagement.Domain/EasyAbp/FileManagement/Files/FileBlobNameGenerator.cs
+++ b/src/EasyAbp.FileManagement.Domain/EasyAbp/FileManagement/Files/FileBlobNameGenerator.cs
@@ -17,9 +17,9 @@ namespace EasyAbp.FileManagement.Files
         public virtual Task<string> CreateAsync(FileType fileType, string fileName, File parent, string mimeType, string directorySeparator)
         {
             var now = _clock.Now;
-
+            FileInfo fileinfo = new FileInfo(fileName);
             var blobName = now.Year + directorySeparator + now.Month + directorySeparator + now.Day +
-                           directorySeparator + Guid.NewGuid().ToString("N");
+                           directorySeparator + Guid.NewGuid().ToString("N") + fileinfo.Extension;
 
             return Task.FromResult(blobName);
         }


### PR DESCRIPTION
使用阿里云oss作为blob container时，如果添加新的blob，以传入的BlobName扩展名解析MIME类型，如果没有扩展名，不能解析为正确的类型，在阿里云管理平台上不能显示。添加扩展名可解决这个问题。