### PR TITLE
Use UTC-kind placeholder for LastModificationTime dirty-marking

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <Version>5.11.0</Version>
+    <Version>5.11.1</Version>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>EasyAbp Team</Authors>

--- a/src/EasyAbp.FileManagement.Domain.Core/EasyAbp/FileManagement/Files/File.cs
+++ b/src/EasyAbp.FileManagement.Domain.Core/EasyAbp/FileManagement/Files/File.cs
@@ -142,7 +142,10 @@ namespace EasyAbp.FileManagement.Files
         public void TriggerAuditingChanges()
         {
             // after ABP v8, LastModificationTime doesn't change if no entity properties have changed.
-            LastModificationTime = DateTime.MinValue;
+            // Use a UTC-kind placeholder so that, if this value were ever serialized before the auditing
+            // interceptor overwrites it, AbpDateTimeConverter won't try to convert an Unspecified-kind
+            // boundary value and emit warnings under a UTC clock with a user timezone.
+            LastModificationTime = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
         }
     }
 }


### PR DESCRIPTION
## Problem

`File.TriggerAuditingChanges()` sets `LastModificationTime = DateTime.MinValue`, which produces an **`Unspecified`-kind** `DateTime` at the range boundary. `FileInfoDto` extends `ExtensibleFullAuditedEntityDto<Guid>`, so `LastModificationTime` is exposed to the UI.

Under a UTC clock (`AbpClockOptions.Kind == DateTimeKind.Utc`) with a current-user timezone set, `AbpDateTimeConverterBase.Normalize` treats an `Unspecified`-kind value as local time and converts it to UTC. For a boundary value like `MinValue` under a positive offset (e.g. `Asia/Shanghai` +08:00), the UTC equivalent falls outside the supported `DateTime` range and throws `ArgumentOutOfRangeException`, which is swallowed and logged as a warning on every serialization.

In the normal flow this value is transient — ABP's auditing interceptor overwrites it with `Clock.Now` during the subsequent `UpdateAsync(autoSave: true)` in `FileCreatedEventHandler` — so this is a defensive/consistency change rather than a fix for an observed log flood.

## Fix

Use `DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc)` as the dirty-marking placeholder. With a `Utc` kind, `AbpDateTimeConverter` performs no timezone conversion, so no boundary overflow can occur. The value still differs from the persisted one, so the dirty-marking trick keeps working.

This mirrors the upstream `Volo.Docs` `GitHubDocumentSource` fix, which returns a `Utc`-kind placeholder instead of a bare `Unspecified` `DateTime.MinValue`.

Bumps the package version to `5.11.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)